### PR TITLE
Fix dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-metascript",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Gulp plugin for metascript",
   "main": "index.js",
   "scripts": {
@@ -16,7 +16,7 @@
     "url": "https://github.com/oNaiPs/gulp-metascript/issues"
   },
   "homepage": "https://github.com/oNaiPs/gulp-metascript",
-  "devDependencies": {
+  "dependencies": {
     "gulp-util": "^3.0.3",
     "metascript": "^1.0.0",
     "through2": "^0.6.3"


### PR DESCRIPTION
I moved all dependencies from devDependencies to dependencies.
All this plugin dependencies needs at work, not just development, so they must be in dependencies section.
